### PR TITLE
Fix Column Click On The Error

### DIFF
--- a/src/components/DataTables.vue
+++ b/src/components/DataTables.vue
@@ -317,7 +317,7 @@ export default {
       this.checkedFilters = checkedFilters
     },
     handleRowClick(row, event, column) {
-      if (this.innerColNotRowClick.indexOf(column.property) === -1) {
+      if (column && this.innerColNotRowClick.indexOf(column.property) === -1) {
         this.$emit('row-click', row)
       }
     },


### PR DESCRIPTION
when the mouse move more than tow colums, it will be in the console error as the following pic

![image](https://cloud.githubusercontent.com/assets/20501873/23743818/0a4a911c-04ed-11e7-8aa8-87217a35bfd7.png)
