### PR TITLE
Update docs Element theme for 2.0 default

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css" >
-  <link rel="stylesheet" href="https://unpkg.com/element-ui/lib/theme-default/index.css">
+  <link rel="stylesheet" href="https://unpkg.com/element-ui/lib/theme-chalk/index.css">
   <link rel="stylesheet" href="css/compatible.css">
 </head>
 <body>
@@ -65,7 +65,7 @@ titles = [{
     + '\n<scr' + `ipt src="//unpkg.com/element-ui/lib/index.js"></scr` + 'ipt>'
     + '\n<scr' + `ipt src="//unpkg.com/element-ui/lib/umd/locale/en.js"></scr` + 'ipt>'
     + '\n<scr' + `ipt src="//unpkg.com/vue-data-tables@2.1.0/dist/data-tables.min.js"></scr` + 'ipt>'
-  var cssResources = '@import url("//unpkg.com/element-ui/lib/theme-default/index.css");'
+  var cssResources = '@import url("//unpkg.com/element-ui/lib/theme-chalk/index.css");'
   var bootCode =
     'ELEMENT.locale(ELEMENT.lang.en)\n'
     + 'Vue.use(DataTables)\n'


### PR DESCRIPTION
This is just a simple patch, so the examples in the docs don't look broken anymore.