### PR TITLE
Typo fixes

### DIFF
--- a/docs/en-us/quickStart.md
+++ b/docs/en-us/quickStart.md
@@ -37,13 +37,13 @@ locale.use(lang)
 ### import bundled vue-data-tables (recommended and straightforward)
 ```js
 // import DataTables and DataTableServer separately
-import { DataTables, DataTablesServer } from 'vue-data-tables';
-Vue.use(DataTables);
-Vue.use(DataTablesServer);
+import { DataTables, DataTablesServer } from 'vue-data-tables'
+Vue.use(DataTables)
+Vue.use(DataTablesServer)
 
 // import DataTables and DataTableServer together
-import VueDataTables from 'vue-data-tables';
-Vue.use(VueDataTables);
+import VueDataTables from 'vue-data-tables'
+Vue.use(VueDataTables)
 ```
 
 ## import vue-data-tables source code
@@ -74,7 +74,7 @@ You can import the source code of this lib to decrease the code size, if you rea
 * revise the `import`
 
 ```
-import { DataTables, DataTablesServer } from 'vue-data-tables/src/index.js';
+import { DataTables, DataTablesServer } from 'vue-data-tables/src/index.js'
 ```
 
 # Hello world

--- a/docs/en-us/quickStart.md
+++ b/docs/en-us/quickStart.md
@@ -5,7 +5,7 @@
 ```
 npm install vue-data-tables
 or
-yarn install vue-data-tables
+yarn add vue-data-tables
 ```
 
 # Import vue-data-tables
@@ -37,12 +37,13 @@ locale.use(lang)
 ### import bundled vue-data-tables (recommended and straightforward)
 ```js
 // import DataTables and DataTableServer separately
-import { DataTables, DataTablesServer } from 'vue-data-tables'
-Vue.use(DataTables)
+import { DataTables, DataTablesServer } from 'vue-data-tables';
+Vue.use(DataTables);
+Vue.use(DataTablesServer);
 
 // import DataTables and DataTableServer together
-import VueDataTables from 'vue-data-tables'
-Vue.use(VueDataTables)
+import VueDataTables from 'vue-data-tables';
+Vue.use(VueDataTables);
 ```
 
 ## import vue-data-tables source code
@@ -73,7 +74,7 @@ You can import the source code of this lib to decrease the code size, if you rea
 * revise the `import`
 
 ```
-import { DataTables, DataTablesServer } from 'vue-data-tables/src/index.js'
+import { DataTables, DataTablesServer } from 'vue-data-tables/src/index.js';
 ```
 
 # Hello world


### PR DESCRIPTION
- `yarn add` instead of `yarn install`
- `Vue.use(DataTablesServer);` added
- Semi colon added.